### PR TITLE
Position: corregidos bugs del commit anterior & nuevas funcionalidades

### DIFF
--- a/src/CppGUI/GUI.cpp
+++ b/src/CppGUI/GUI.cpp
@@ -421,19 +421,29 @@ GUI::DrawFlight(ATCDisplay::ATCDFlight flight)
 			glColor4f(0.0f,0.0f,1.0f, 1.0f);
 			glBegin(GL_LINES);
 
+			float aux_alt;
 			glVertex3f(flight.pos.x, flight.pos.y, flight.pos.z);
 			for(it = route.begin(); it!=route.end(); ++it)
 			{
-				glVertex3f((*it).x, (*it).y, (*it).z);
-				glVertex3f((*it).x, (*it).y, (*it).z);
+				// If point of route has no altitude, draw last altitude
+				if((*it).z > MAINTAIN_ALT)
+					aux_alt = (*it).z;
+
+				glVertex3f((*it).x, (*it).y, aux_alt);
+				glVertex3f((*it).x, (*it).y, aux_alt);
 			}
 			glEnd();
 
+
 			for(it = route.begin(); it!=route.end(); ++it)
 			{
+				// If point of route has no altitude, draw last altitude
+				if((*it).z > MAINTAIN_ALT)
+					aux_alt = (*it).z;
+
 				glColor4f(0.0f,0.0f,1.0f, 1.0f);
 				glPushMatrix();
-				glTranslatef((*it).x, (*it).y,(*it).z);
+				glTranslatef((*it).x, (*it).y, aux_alt);
 				GLUquadric *quadratic = gluNewQuadric();
 				gluQuadricNormals(quadratic, GLU_SMOOTH);
 				gluQuadricTexture(quadratic, GL_TRUE);

--- a/src/lib/Common.h
+++ b/src/lib/Common.h
@@ -64,6 +64,11 @@
 #define LANDING_POS_Y 0.0f
 #define LANDING_POS_Z 25.0f
 
+// Lowest airport in the word is at -1240 ft
+// and lowest land zone in Earth is -3904 ft
+#define MIN_AIRPORT_ALT -4000.0f
+#define MAINTAIN_ALT MIN_AIRPORT_ALT
+
 
 #define LANDING_SPEED 20.0f
 #define LANDING_BEAR -180.0f

--- a/src/simulator/AirController.cpp
+++ b/src/simulator/AirController.cpp
@@ -46,7 +46,7 @@ AirController::doWork()
 			std::list<Flight*>::iterator it;
 
 			Position pos0(3500.0, 0.0, 100.0);
-			Position pos1(1500.0, 0.0, -1.0);
+			Position pos1(1500.0, 0.0, MAINTAIN_ALT);
 			Position pos2(200.0, 0.0, 25.0);
 			Position pos3(-750.0, 0.0, 25.0);
 

--- a/src/simulator/Flight.cpp
+++ b/src/simulator/Flight.cpp
@@ -74,8 +74,11 @@ Flight::update(float delta_t)
 
 		CPpos = route.front().pos;
 
-		if(CPpos.get_z() < 0) // Maintain altitude
-			route.front().pos.set_z((this->getPosition()).get_z());
+		if(CPpos.get_z() <= MAINTAIN_ALT){ // Maintain altitude
+			float current_alt = (this->getPosition()).get_z();
+			CPpos.set_z(current_alt);
+			route.front().pos.set_z(current_alt);
+		}
 
 		pos.angles(CPpos, goal_bearing, inclination);
 

--- a/src/simulator/Position.cpp
+++ b/src/simulator/Position.cpp
@@ -31,8 +31,15 @@ Position::Position() {
 
 	name = "";
 	x = y = 0.0;
-	z = -1.0;
+	z = MAINTAIN_ALT;
+}
 
+Position::Position(float _x, float _y)
+{
+	name = "";
+	x = _x;
+	y = _y;
+	z = MAINTAIN_ALT;
 }
 
 Position::Position(float _x, float _y, float _z)
@@ -41,6 +48,14 @@ Position::Position(float _x, float _y, float _z)
 	x = _x;
 	y = _y;
 	z = _z;
+}
+
+Position::Position(std::string _name, float _x, float _y)
+{
+	name = check_name(_name);
+	x = _x;
+	y = _y;
+	z = MAINTAIN_ALT;
 }
 
 Position::Position(std::string _name, float _x, float _y, float _z)

--- a/src/simulator/Position.h
+++ b/src/simulator/Position.h
@@ -25,6 +25,7 @@
 #ifndef POSITION_H_
 #define POSITION_H_
 
+#include "Common.h"
 #include <string>
 
 namespace atcsim{
@@ -32,7 +33,9 @@ namespace atcsim{
 class Position {
 public:
 	Position();
+	Position(float _x, float _y);
 	Position(float _x, float _y, float _z);
+	Position(std::string _name, float _x, float _y);
 	Position(std::string _name, float _x, float _y, float _z);
 	virtual ~Position();
 


### PR DESCRIPTION
- Al dibujar un punto en el que se debía mantener altitud, se dibujaba en -1. Se ha corregido y ahora se dibuja a la altitud del punto anterior (luego puede haber correcciones leves porque el avión no pase por el punto anterior a la altitud de consigna sino con un leve error).

- Cambiado el valor de mantener altitud por otro que permite compatibilidad con aeropuertos que se encuentren por debajo del nivel del mar.

- Al cambiarlo ha dado la cara un fallo en el FLight::update() que establecía inclinaciones muy grandes por no asignar la altitud en el punto siguiente de la ruta para hacer los cálculos (sí se añadía en la lista de ruta).