### PR TITLE
FIX: violación segmento GUI.cpp

### DIFF
--- a/src/CppGUI/GUI.cpp
+++ b/src/CppGUI/GUI.cpp
@@ -400,7 +400,12 @@ GUI::DrawFlight(ATCDisplay::ATCDFlight flight) {
         float lineSpace = 320;
         float lineVertPos = flight.pos.x - lineSpace;
 
-        ATCDisplay::ATCDPosition nextPos = *route.begin();
+        std::vector<ATCDisplay::ATCDPosition>::iterator auxIt;
+        auxIt = route.begin();
+
+        ATCDisplay::ATCDPosition nextPos;
+        if(auxIt != route.end())
+            nextPos = *auxIt;
 
         std::string textArray[3];
         // Show flight ID


### PR DESCRIPTION
Esto corrige un error de violación de segmento que se produce de manera "aleatoria" a deferenciar el iterador, comprobándose ahora que el iterador es válido.

Esto soluciona el cierre de la ventana de visualización del simulador de forma inesperada mientras el simulador sigue corriendo.